### PR TITLE
Av/ttgo tdisplay

### DIFF
--- a/player/platformio.ini
+++ b/player/platformio.ini
@@ -199,3 +199,46 @@ build_flags =
 ; decode exceptions
 monitor_filters = esp32_exception_decoder
 monitor_speed = 115200
+
+[env:tdisplay]
+platform = espressif32 @ 4.4.0
+board = esp32dev
+framework = arduino
+lib_deps =
+  SPI
+  bodmer/TFT_eSPI
+  bitbank2/JPEGDEC
+  z3t0/IRremote
+  bblanchon/ArduinoJson
+build_flags = 
+  -DTDISPLAY
+  ; maximum speed!
+  -Ofast
+  -DUSE_DMA
+  ; TFT_eSPI setup
+  -DUSER_SETUP_LOADED
+  -DTFT_WIDTH=135
+  -DTFT_HEIGHT=240
+  -DST7789_DRIVER=1
+  -DTFT_SCLK=18
+  -DTFT_MOSI=19
+  -DTFT_RST=23
+  -DTFT_DC=16
+  -DTFT_CS=5
+  -DTFT_BL=4
+  -DTFT_BACKLIGHT_ON=HIGH
+  -DLOAD_FONT2=1
+  -DSPI_FREQUENCY=40000000
+  -DSPI_READ_FREQUENCY=6000000
+  ; audio settings - cheap yellow display uses the DAC
+  -DUSE_DAC_AUDIO
+  ; SD card
+  -DUSE_SDCARD
+  -DSD_CARD_MISO=GPIO_NUM_27
+  -DSD_CARD_MOSI=GPIO_NUM_15
+  -DSD_CARD_CLK=GPIO_NUM_13
+  -DSD_CARD_CS=GPIO_NUM_2
+; decode exceptions
+monitor_filters = esp32_exception_decoder
+monitor_speed = 115200
+

--- a/player/src/SDCard.cpp
+++ b/player/src/SDCard.cpp
@@ -7,10 +7,15 @@
 
 SDCard::SDCard(int miso, int mosi, int clk, int cs)
 {
+  #ifndef TDISPLAY
   spi.setFrequency(80000000);
   spi.begin(clk, miso, mosi, cs);
 
   if (!SD.begin(cs, spi, 80000000))
+  #else
+  spi.begin(clk, miso, mosi, cs);
+  if (!SD.begin(cs, spi))
+  #endif
   {
     Serial.println("Card Mount Failed");
     return;


### PR DESCRIPTION
## Overview

Basic support for LilyGO T-Display (ESP32 version) board. In the next PRs I'm going to add  poweroff and toggle channel button support for this board.

- [x] tested in real hardware
- [x] limited to Espressif 4.4.0 for preserve ROM space
- [x] fixed issue with SPI frequency in this board.  