### PR TITLE
Av/m5core2aws

### DIFF
--- a/player/platformio.ini
+++ b/player/platformio.ini
@@ -17,7 +17,6 @@ build_flags =
   -D CORE_DEBUG_LEVEL=0         # For debugging set to 3 and enable debug mode in the app
   -Ofast                        # maximum speed!
 lib_deps =
-  SPI
   bodmer/TFT_eSPI
   bitbank2/JPEGDEC
   z3t0/IRremote
@@ -185,7 +184,7 @@ build_flags =
 
 [env:tdisplay]
 extends = esp32_common
-platform = espressif32 @ 4.4.0
+platform = espressif32
 board = esp32dev
 build_flags = 
   ${common.build_flags}
@@ -222,16 +221,16 @@ build_flags =
   -DSD_CARD_CS=GPIO_NUM_2
 
 [env:m5core2]
-extends = esp32_common
-platform = espressif32
+extends = esp32_common 
+platform = espressif32 @ 4.4.0
 board = esp32dev
 build_flags = 
   ${common.build_flags}
+  -DM5CORE2
   -DUSE_DMA
   ; TFT_eSPI setup
   -DUSER_SETUP_LOADED
   -DILI9342_DRIVER=1
-  -DTFT_SDA_READ=1
   -DTFT_INVERSION_ON=1
   -DTFT_MISO=38
   -DTFT_MOSI=23
@@ -242,18 +241,17 @@ build_flags =
   -DTOUCH_CS=-1
   -DLOAD_GLCD=1
   -DLOAD_FONT2=1
-  -DLOAD_FONT4=1
-  -DLOAD_FONT6=1
-  -DLOAD_FONT7=1
-  -DLOAD_FONT8=1
-  -DLOAD_GFXFF=1
   -DSPI_FREQUENCY=40000000
-  -DSPI_READ_FREQUENCY=16000000
+  -DSPI_READ_FREQUENCY=8000000
   ; audio settings - cheap yellow display uses the DAC
-  -DUSE_DAC_AUDIO
+  -DI2S_SPEAKER_SERIAL_CLOCK=GPIO_NUM_12
+  -DI2S_SPEAKER_LEFT_RIGHT_CLOCK=GPIO_NUM_0
+  -DI2S_SPEAKER_SERIAL_DATA=GPIO_NUM_2
   ; SD card
-  -DUSE_SDCARD
-  -DSD_CARD_MISO=GPIO_NUM_38
-  -DSD_CARD_MOSI=GPIO_NUM_23
-  -DSD_CARD_CLK=GPIO_NUM_18
-  -DSD_CARD_CS=GPIO_NUM_4
+  ; TODO: it fails, detect it but it can't mount: https://github.com/m5stack/M5Core2/issues/136
+  ;
+  ; -DUSE_SDCARD
+  ; -DSD_CARD_MISO=GPIO_NUM_38
+  ; -DSD_CARD_MOSI=GPIO_NUM_23
+  ; -DSD_CARD_CLK=GPIO_NUM_18
+  ; -DSD_CARD_CS=GPIO_NUM_4

--- a/player/platformio.ini
+++ b/player/platformio.ini
@@ -17,6 +17,7 @@ build_flags =
   -D CORE_DEBUG_LEVEL=0         # For debugging set to 3 and enable debug mode in the app
   -Ofast                        # maximum speed!
 lib_deps =
+  SPI
   bodmer/TFT_eSPI
   bitbank2/JPEGDEC
   z3t0/IRremote
@@ -184,7 +185,7 @@ build_flags =
 
 [env:tdisplay]
 extends = esp32_common
-platform = espressif32
+platform = espressif32 @ 4.4.0
 board = esp32dev
 build_flags = 
   ${common.build_flags}
@@ -206,6 +207,7 @@ build_flags =
   -DSPI_FREQUENCY=40000000
   -DSPI_READ_FREQUENCY=6000000
   ; buttons
+  -DBUTTONS
   -DBUTTON_L=0
   -DBUTTON_R=35
   ; HAL misc
@@ -227,6 +229,7 @@ board = esp32dev
 build_flags = 
   ${common.build_flags}
   -DM5CORE2
+  -DBUTTONS
   -DUSE_DMA
   ; TFT_eSPI setup
   -DUSER_SETUP_LOADED

--- a/player/platformio.ini
+++ b/player/platformio.ini
@@ -206,8 +206,9 @@ build_flags =
   -DLOAD_FONT2=1
   -DSPI_FREQUENCY=40000000
   -DSPI_READ_FREQUENCY=6000000
+  -DTOUCH_CS=-1
   ; buttons
-  -DBUTTONS
+  -DHAS_BUTTONS
   -DBUTTON_L=0
   -DBUTTON_R=35
   ; HAL misc
@@ -229,7 +230,7 @@ board = esp32dev
 build_flags = 
   ${common.build_flags}
   -DM5CORE2
-  -DBUTTONS
+  -DHAS_BUTTONS
   -DUSE_DMA
   ; TFT_eSPI setup
   -DUSER_SETUP_LOADED

--- a/player/platformio.ini
+++ b/player/platformio.ini
@@ -31,6 +31,7 @@ framework = ${common.framework}
 monitor_speed = ${common.monitor_speed}
 build_flags = ${common.build_flags}
 lib_deps = ${common.lib_deps}
+monitor_filters = ${common.monitor_filters}
 
 [env:atomic14-custom-pcb]
 extends = esp32_common
@@ -219,3 +220,40 @@ build_flags =
   -DSD_CARD_MOSI=GPIO_NUM_15
   -DSD_CARD_CLK=GPIO_NUM_13
   -DSD_CARD_CS=GPIO_NUM_2
+
+[env:m5core2]
+extends = esp32_common
+platform = espressif32
+board = esp32dev
+build_flags = 
+  ${common.build_flags}
+  -DUSE_DMA
+  ; TFT_eSPI setup
+  -DUSER_SETUP_LOADED
+  -DILI9342_DRIVER=1
+  -DTFT_SDA_READ=1
+  -DTFT_INVERSION_ON=1
+  -DTFT_MISO=38
+  -DTFT_MOSI=23
+  -DTFT_SCLK=18
+  -DTFT_CS=5
+  -DTFT_DC=15
+  -DTFT_RST=-1
+  -DTOUCH_CS=-1
+  -DLOAD_GLCD=1
+  -DLOAD_FONT2=1
+  -DLOAD_FONT4=1
+  -DLOAD_FONT6=1
+  -DLOAD_FONT7=1
+  -DLOAD_FONT8=1
+  -DLOAD_GFXFF=1
+  -DSPI_FREQUENCY=40000000
+  -DSPI_READ_FREQUENCY=16000000
+  ; audio settings - cheap yellow display uses the DAC
+  -DUSE_DAC_AUDIO
+  ; SD card
+  -DUSE_SDCARD
+  -DSD_CARD_MISO=GPIO_NUM_38
+  -DSD_CARD_MOSI=GPIO_NUM_23
+  -DSD_CARD_CLK=GPIO_NUM_18
+  -DSD_CARD_CS=GPIO_NUM_4

--- a/player/src/AXP192.cpp
+++ b/player/src/AXP192.cpp
@@ -1,0 +1,552 @@
+#include "AXP192.h"
+
+AXP192::AXP192() {}
+
+// Will be deprecated
+void AXP192::begin(mbus_mode_t mode) { begin(); }
+
+void AXP192::begin() {
+  Wire1.begin(21, 22);
+  Wire1.setClock(400000);
+
+  //AXP192 30H
+  Write1Byte(0x30, (Read8bit(0x30) & 0x04) | 0X02);
+  Serial.printf("axp: vbus limit off\n");
+
+  //AXP192 GPIO1:OD OUTPUT
+  Write1Byte(0x92, Read8bit(0x92) & 0xf8);
+  Serial.printf("axp: gpio1 init\n");
+
+  //AXP192 GPIO2:OD OUTPUT
+  Write1Byte(0x93, Read8bit(0x93) & 0xf8);
+  Serial.printf("axp: gpio2 init\n");
+
+  //AXP192 RTC CHG
+  Write1Byte(0x35, (Read8bit(0x35) & 0x1c) | 0xa2);
+  Serial.printf("axp: rtc battery charging enabled\n");
+
+  SetESPVoltage(3350);
+  Serial.printf("axp: esp32 power voltage was set to 3.35v\n");
+
+  SetLcdVoltage(2800);
+  Serial.printf("axp: lcd backlight voltage was set to 2.80v\n");
+
+  SetLDOVoltage(2, 3300);  //Periph power voltage preset (LCD_logic, SD card)
+  Serial.printf("axp: lcd logic and sdcard voltage preset to 3.3v\n");
+
+  SetLDOVoltage(3, 2000);  //Vibrator power voltage preset
+  Serial.printf("axp: vibrator voltage preset to 2v\n");
+
+  SetLDOEnable(2, true);
+  SetDCDC3(true);  // LCD backlight
+  SetLed(true);
+
+  SetCHGCurrent(kCHG_100mA);
+  //SetAxpPriphPower(1);
+  //Serial.printf("axp: lcd_logic and sdcard power enabled\n\n");
+
+  //pinMode(39, INPUT_PULLUP);
+
+  //AXP192 GPIO4
+  Write1Byte(0X95, (Read8bit(0x95) & 0x72) | 0X84);
+
+  Write1Byte(0X36, 0X4C);
+
+  Write1Byte(0x82, 0xff);
+
+  SetLCDRSet(0);
+  delay(100);
+  SetLCDRSet(1);
+  delay(100);
+  // I2C_WriteByteDataAt(0X15,0XFE,0XFF);
+
+  SetPeripherialsPower(true);
+
+  // axp: check v-bus status
+  if (Read8bit(0x00) & 0x08) {
+    Write1Byte(0x30, Read8bit(0x30) | 0x80);
+    // if v-bus can use, disable M-Bus 5V output to input
+    SetBusPowerMode(kMBusModeInput);
+  } else {
+    // if not, enable M-Bus 5V output
+    SetBusPowerMode(kMBusModeOutput);
+  }
+}
+
+void AXP192::Write1Byte(uint8_t Addr, uint8_t Data) {
+  Wire1.beginTransmission(0x34);
+  Wire1.write(Addr);
+  Wire1.write(Data);
+  Wire1.endTransmission();
+}
+
+uint8_t AXP192::Read8bit(uint8_t Addr) {
+  Wire1.beginTransmission(0x34);
+  Wire1.write(Addr);
+  Wire1.endTransmission();
+  Wire1.requestFrom(0x34, 1);
+  return Wire1.read();
+}
+
+uint16_t AXP192::Read12Bit(uint8_t Addr) {
+  uint16_t Data = 0;
+  uint8_t buf[2];
+  ReadBuff(Addr, 2, buf);
+  Data = ((buf[0] << 4) + buf[1]);  //
+  return Data;
+}
+
+uint16_t AXP192::Read13Bit(uint8_t Addr) {
+  uint16_t Data = 0;
+  uint8_t buf[2];
+  ReadBuff(Addr, 2, buf);
+  Data = ((buf[0] << 5) + buf[1]);  //
+  return Data;
+}
+
+uint16_t AXP192::Read16bit(uint8_t Addr) {
+  uint16_t ReData = 0;
+  Wire1.beginTransmission(0x34);
+  Wire1.write(Addr);
+  Wire1.endTransmission();
+  Wire1.requestFrom(0x34, 2);
+  for (int i = 0; i < 2; i++) {
+    ReData <<= 8;
+    ReData |= Wire1.read();
+  }
+  return ReData;
+}
+
+uint32_t AXP192::Read24bit(uint8_t Addr) {
+  uint32_t ReData = 0;
+  Wire1.beginTransmission(0x34);
+  Wire1.write(Addr);
+  Wire1.endTransmission();
+  Wire1.requestFrom(0x34, 3);
+  for (int i = 0; i < 3; i++) {
+    ReData <<= 8;
+    ReData |= Wire1.read();
+  }
+  return ReData;
+}
+
+uint32_t AXP192::Read32bit(uint8_t Addr) {
+  uint32_t ReData = 0;
+  Wire1.beginTransmission(0x34);
+  Wire1.write(Addr);
+  Wire1.endTransmission();
+  Wire1.requestFrom(0x34, 4);
+  for (int i = 0; i < 4; i++) {
+    ReData <<= 8;
+    ReData |= Wire1.read();
+  }
+  return ReData;
+}
+
+void AXP192::ReadBuff(uint8_t Addr, uint8_t Size, uint8_t *Buff) {
+  Wire1.beginTransmission(0x34);
+  Wire1.write(Addr);
+  Wire1.endTransmission();
+  Wire1.requestFrom(0x34, (int)Size);
+  for (int i = 0; i < Size; i++) {
+    *(Buff + i) = Wire1.read();
+  }
+}
+
+void AXP192::ScreenBreath(int brightness) {
+  if (brightness >= 100)
+    brightness = 100;
+  else if (brightness < 0)
+    brightness = 0;
+  int vol = map(brightness, 0, 100, 2400, 3300);
+  // Serial.printf("brightness:%d\n", brightness);
+
+  // Serial.printf("vol:%d\n", vol);
+  // Serial.printf("vol:%u\n", vol);
+
+  SetLcdVoltage((uint16_t)vol);
+  // delay(10);
+  // uint8_t buf = Read8bit(0x27);
+  // Serial.printf("brightness:%hhu\n", brightness);
+  // Serial.printf("brightness:%d\n", brightness);
+  // Serial.printf("brightness:%x\n", brightness);
+
+  // Serial.printf("buf:%hhu\n", buf);
+  // Serial.printf("buf:%d\n", buf);
+  // Serial.printf("buf:%x\n", buf);
+
+  // Serial.printf("result:%hhu\n", ((buf & 0x0f) | (brightness << 4)));
+  // Serial.printf("result:%d\n", ((buf & 0x0f) | (brightness << 4)));
+  // Serial.printf("result:%x\n", ((buf & 0x0f) | (brightness << 4)));
+
+  // Write1Byte(0x27, ((buf & 0x0f) | (brightness << 4)));
+}
+
+bool AXP192::GetBatState() {
+  if (Read8bit(0x01) | 0x20)
+    return true;
+  else
+    return false;
+}
+//---------coulombcounter_from_here---------
+//enable: void EnableCoulombcounter(void);
+//disable: void DisableCOulombcounter(void);
+//stop: void StopCoulombcounter(void);
+//clear: void ClearCoulombcounter(void);
+//get charge data: uint32_t GetCoulombchargeData(void);
+//get discharge data: uint32_t GetCoulombdischargeData(void);
+//get coulomb val affter calculation: float GetCoulombData(void);
+//------------------------------------------
+void AXP192::EnableCoulombcounter(void) { Write1Byte(0xB8, 0x80); }
+
+void AXP192::DisableCoulombcounter(void) { Write1Byte(0xB8, 0x00); }
+
+void AXP192::StopCoulombcounter(void) { Write1Byte(0xB8, 0xC0); }
+
+void AXP192::ClearCoulombcounter(void) { Write1Byte(0xB8, 0xA0); }
+
+uint32_t AXP192::GetCoulombchargeData(void) { return Read32bit(0xB0); }
+
+uint32_t AXP192::GetCoulombdischargeData(void) { return Read32bit(0xB4); }
+
+float AXP192::GetCoulombData(void) {
+  uint32_t coin = 0;
+  uint32_t coout = 0;
+
+  coin = GetCoulombchargeData();
+  coout = GetCoulombdischargeData();
+
+  //c = 65536 * current_LSB * (coin - coout) / 3600 / ADC rate
+  //Adc rate can be read from 84H ,change this variable if you change the ADC reate
+  float ccc = 65536 * 0.5 * (int32_t)(coin - coout) / 3600.0 / 25.0;
+  return ccc;
+}
+
+// Cut all power, except for LDO1 (RTC)
+void AXP192::PowerOff(void) { Write1Byte(0x32, Read8bit(0x32) | 0b10000000); }
+
+void AXP192::SetAdcState(bool state) {
+  // Enable / Disable all ADCs
+  Write1Byte(0x82, state ? 0xff : 0x00);
+}
+
+void AXP192::PrepareToSleep(void) {
+  // Disable ADCs
+  SetAdcState(false);
+
+  // Turn LED off
+  SetLed(false);
+
+  // Turn LCD backlight off
+  SetDCDC3(false);
+}
+
+// Get current battery level
+float AXP192::GetBatteryLevel(void) {
+  const float batVoltage = GetBatVoltage();
+  const float batPercentage =
+      (batVoltage < 3.248088) ? (0) : (batVoltage - 3.120712) * 100;
+  return (batPercentage <= 100) ? batPercentage : 100;
+}
+
+void AXP192::RestoreFromLightSleep(void) {
+  // Turn LCD backlight on
+  SetDCDC3(true);
+
+  // Turn LED on
+  SetLed(true);
+
+  // Enable ADCs
+  SetAdcState(true);
+}
+
+uint8_t AXP192::GetWarningLeve(void) {
+  Wire1.beginTransmission(0x34);
+  Wire1.write(0x47);
+  Wire1.endTransmission();
+  Wire1.requestFrom(0x34, 1);
+  uint8_t buf = Wire1.read();
+  return (buf & 0x01);
+}
+
+// -- sleep
+void AXP192::DeepSleep(uint64_t time_in_us) {
+  PrepareToSleep();
+
+  if (time_in_us > 0) {
+    esp_sleep_enable_timer_wakeup(time_in_us);
+  } else {
+    esp_sleep_disable_wakeup_source(ESP_SLEEP_WAKEUP_TIMER);
+  }
+  (time_in_us == 0) ? esp_deep_sleep_start() : esp_deep_sleep(time_in_us);
+
+  // Never reached - after deep sleep ESP32 restarts
+}
+
+void AXP192::LightSleep(uint64_t time_in_us) {
+  PrepareToSleep();
+
+  if (time_in_us > 0) {
+    esp_sleep_enable_timer_wakeup(time_in_us);
+  } else {
+    esp_sleep_disable_wakeup_source(ESP_SLEEP_WAKEUP_TIMER);
+  }
+  esp_light_sleep_start();
+
+  RestoreFromLightSleep();
+}
+
+uint8_t AXP192::GetWarningLevel(void) { return Read8bit(0x47) & 0x01; }
+
+float AXP192::GetBatVoltage() {
+  float ADCLSB = 1.1 / 1000.0;
+  uint16_t ReData = Read12Bit(0x78);
+  return ReData * ADCLSB;
+}
+
+float AXP192::GetBatCurrent() {
+  float ADCLSB = 0.5;
+  uint16_t CurrentIn = Read13Bit(0x7A);
+  uint16_t CurrentOut = Read13Bit(0x7C);
+  return (CurrentIn - CurrentOut) * ADCLSB;
+}
+
+float AXP192::GetVinVoltage() {
+  float ADCLSB = 1.7 / 1000.0;
+  uint16_t ReData = Read12Bit(0x56);
+  return ReData * ADCLSB;
+}
+
+float AXP192::GetVinCurrent() {
+  float ADCLSB = 0.625;
+  uint16_t ReData = Read12Bit(0x58);
+  return ReData * ADCLSB;
+}
+
+float AXP192::GetVBusVoltage() {
+  float ADCLSB = 1.7 / 1000.0;
+  uint16_t ReData = Read12Bit(0x5A);
+  return ReData * ADCLSB;
+}
+
+float AXP192::GetVBusCurrent() {
+  float ADCLSB = 0.375;
+  uint16_t ReData = Read12Bit(0x5C);
+  return ReData * ADCLSB;
+}
+
+float AXP192::GetTempInAXP192() {
+  float ADCLSB = 0.1;
+  const float OFFSET_DEG_C = -144.7;
+  uint16_t ReData = Read12Bit(0x5E);
+  return OFFSET_DEG_C + ReData * ADCLSB;
+}
+
+float AXP192::GetBatPower() {
+  float VoltageLSB = 1.1;
+  float CurrentLCS = 0.5;
+  uint32_t ReData = Read24bit(0x70);
+  return VoltageLSB * CurrentLCS * ReData / 1000.0;
+}
+
+float AXP192::GetBatChargeCurrent() {
+  float ADCLSB = 0.5;
+  uint16_t ReData = Read12Bit(0x7A);
+  return ReData * ADCLSB;
+}
+float AXP192::GetAPSVoltage() {
+  float ADCLSB = 1.4 / 1000.0;
+  uint16_t ReData = Read12Bit(0x7E);
+  return ReData * ADCLSB;
+}
+
+float AXP192::GetBatCoulombInput() {
+  uint32_t ReData = Read32bit(0xB0);
+  return ReData * 65536 * 0.5 / 3600 / 25.0;
+}
+
+float AXP192::GetBatCoulombOut() {
+  uint32_t ReData = Read32bit(0xB4);
+  return ReData * 65536 * 0.5 / 3600 / 25.0;
+}
+
+void AXP192::SetCoulombClear() { Write1Byte(0xB8, 0x20); }
+
+void AXP192::SetLDO2(bool State) {
+  uint8_t buf = Read8bit(0x12);
+  if (State == true)
+    buf = (1 << 2) | buf;
+  else
+    buf = ~(1 << 2) & buf;
+  Write1Byte(0x12, buf);
+}
+
+void AXP192::SetDCDC3(bool State) {
+  uint8_t buf = Read8bit(0x12);
+  if (State == true)
+    buf = (1 << 1) | buf;
+  else
+    buf = ~(1 << 1) & buf;
+  Write1Byte(0x12, buf);
+}
+
+uint8_t AXP192::AXPInState() { return Read8bit(0x00); }
+bool AXP192::isACIN() { return (Read8bit(0x00) & 0x80) ? true : false; }
+bool AXP192::isCharging() { return (Read8bit(0x00) & 0x04) ? true : false; }
+bool AXP192::isVBUS() { return (Read8bit(0x00) & 0x20) ? true : false; }
+
+uint8_t calcVoltageData(uint16_t value, uint16_t maxv, uint16_t minv,
+                        uint16_t step) {
+  uint8_t data = 0;
+  if (value > maxv) value = maxv;
+  if (value > minv) data = (value - minv) / step;
+  return data;
+}
+
+void AXP192::SetLDOVoltage(uint8_t number, uint16_t voltage) {
+  uint8_t vdata = calcVoltageData(voltage, 3300, 1800, 100) & 0x0F;
+  switch (number) {
+    //uint8_t reg, data;
+    case 2:
+      Write1Byte(0x28, (Read8bit(0x28) & 0x0F) | (vdata << 4));
+      break;
+    case 3:
+      Write1Byte(0x28, (Read8bit(0x28) & 0xF0) | vdata);
+      break;
+  }
+}
+
+/// @param number 0=DCDC1 / 1=DCDC2 / 2=DCDC3
+void AXP192::SetDCVoltage(uint8_t number, uint16_t voltage) {
+  uint8_t addr;
+  uint8_t vdata;
+  if (number > 2) return;
+  switch (number) {
+    case 0:
+      addr = 0x26;
+      vdata = calcVoltageData(voltage, 3500, 700, 25) & 0x7F;
+      break;
+    case 1:
+      addr = 0x25;
+      vdata = calcVoltageData(voltage, 2275, 700, 25) & 0x3F;
+      break;
+    case 2:
+      addr = 0x27;
+      vdata = calcVoltageData(voltage, 3500, 700, 25) & 0x7F;
+      break;
+  }
+  // Serial.printf("result:%hhu\n", (Read8bit(addr) & 0X80) | (voltage & 0X7F));
+  // Serial.printf("result:%d\n", (Read8bit(addr) & 0X80) | (voltage & 0X7F));
+  // Serial.printf("result:%x\n", (Read8bit(addr) & 0X80) | (voltage & 0X7F));
+  Write1Byte(addr, (Read8bit(addr) & 0x80) | vdata);
+}
+
+void AXP192::SetESPVoltage(uint16_t voltage) {
+  if (voltage >= 3000 && voltage <= 3400) {
+    SetDCVoltage(0, voltage);
+  }
+}
+
+void AXP192::SetLcdVoltage(uint16_t voltage) {
+  if (voltage >= 2500 && voltage <= 3300) {
+    SetDCVoltage(2, voltage);
+  }
+}
+
+void AXP192::SetLDOEnable(uint8_t number, bool state) {
+  uint8_t mark = 0x01;
+  if ((number < 2) || (number > 3)) return;
+
+  mark <<= number;
+  if (state) {
+    Write1Byte(0x12, (Read8bit(0x12) | mark));
+  } else {
+    Write1Byte(0x12, (Read8bit(0x12) & (~mark)));
+  }
+}
+
+void AXP192::SetLCDRSet(bool state) {
+  uint8_t reg_addr = 0x96;
+  uint8_t gpio_bit = 0x02;
+  uint8_t data;
+  data = Read8bit(reg_addr);
+
+  if (state) {
+    data |= gpio_bit;
+  } else {
+    data &= ~gpio_bit;
+  }
+
+  Write1Byte(reg_addr, data);
+}
+
+// Select source for BUS_5V
+// 0 : use internal boost
+// 1 : powered externally
+void AXP192::SetBusPowerMode(uint8_t state) {
+  uint8_t data;
+  if (state == 0) {
+    // Set GPIO to 3.3V (LDO OUTPUT mode)
+    data = Read8bit(0x91);
+    Write1Byte(0x91, (data & 0x0F) | 0xF0);
+    // Set GPIO0 to LDO OUTPUT, pullup N_VBUSEN to disable VBUS supply from BUS_5V
+    data = Read8bit(0x90);
+    Write1Byte(0x90, (data & 0xF8) | 0x02);
+    // Set EXTEN to enable 5v boost
+    data = Read8bit(0x10);
+    Write1Byte(0x10, data | 0x04);
+  } else {
+    // Set EXTEN to disable 5v boost
+    data = Read8bit(0x10);
+    Write1Byte(0x10, data & ~0x04);
+    // Set GPIO0 to float, using enternal pulldown resistor to enable VBUS supply from BUS_5V
+    data = Read8bit(0x90);
+    Write1Byte(0x90, (data & 0xF8) | 0x07);
+  }
+}
+
+void AXP192::SetLed(uint8_t state) {
+  uint8_t reg_addr = 0x94;
+  uint8_t data;
+  data = Read8bit(reg_addr);
+
+  if (state) {
+    data = data & 0XFD;
+  } else {
+    data |= 0X02;
+  }
+
+  Write1Byte(reg_addr, data);
+}
+
+//set led state(GPIO high active,set 1 to enable amplifier)
+void AXP192::SetSpkEnable(uint8_t state) {
+  uint8_t reg_addr = 0x94;
+  uint8_t gpio_bit = 0x04;
+  uint8_t data;
+  data = Read8bit(reg_addr);
+
+  if (state) {
+    data |= gpio_bit;
+  } else {
+    data &= ~gpio_bit;
+  }
+
+  Write1Byte(reg_addr, data);
+}
+
+void AXP192::SetCHGCurrent(uint8_t state) {
+  uint8_t data = Read8bit(0x33);
+  data &= 0xf0;
+  data = data | (state & 0x0f);
+  Write1Byte(0x33, data);
+}
+
+void AXP192::SetPeripherialsPower(uint8_t state) {
+  if (!state)
+    Write1Byte(0x10, Read8bit(0x10) & 0XFB);
+  else if (state)
+    Write1Byte(0x10, Read8bit(0x10) | 0X04);
+  // uint8_t data;
+  // Set EXTEN to enable 5v boost
+}

--- a/player/src/AXP192.h
+++ b/player/src/AXP192.h
@@ -1,0 +1,113 @@
+#ifndef __AXP192_H__
+#define __AXP192_H__
+
+#include <Wire.h>
+#include <Arduino.h>
+
+#define SLEEP_MSEC(us) (((uint64_t)us) * 1000L)
+#define SLEEP_SEC(us) (((uint64_t)us) * 1000000L)
+#define SLEEP_MIN(us) (((uint64_t)us) * 60L * 1000000L)
+#define SLEEP_HR(us) (((uint64_t)us) * 60L * 60L * 1000000L)
+
+#define AXP_ADDR 0X34
+
+#define PowerOff(x) SetSleep(x)
+
+typedef enum {
+  kMBusModeOutput = 0,  // powered by USB or Battery
+  kMBusModeInput = 1    // powered by outside input
+} mbus_mode_t;
+
+class AXP192 {
+ public:
+  enum CHGCurrent {
+    kCHG_100mA = 0,
+    kCHG_190mA,
+    kCHG_280mA,
+    kCHG_360mA,
+    kCHG_450mA,
+    kCHG_550mA,
+    kCHG_630mA,
+    kCHG_700mA,
+    kCHG_780mA,
+    kCHG_880mA,
+    kCHG_960mA,
+    kCHG_1000mA,
+    kCHG_1080mA,
+    kCHG_1160mA,
+    kCHG_1240mA,
+    kCHG_1320mA,
+  };
+
+  AXP192();
+  void begin();
+  // Will be deprecated
+  void begin(mbus_mode_t mode);
+  void ScreenBreath(int brightness);
+  bool GetBatState();
+
+  void EnableCoulombcounter(void);
+  void DisableCoulombcounter(void);
+  void StopCoulombcounter(void);
+  void ClearCoulombcounter(void);
+  uint32_t GetCoulombchargeData(void);
+  uint32_t GetCoulombdischargeData(void);
+  float GetCoulombData(void);
+  float GetBatteryLevel(void);
+  void PowerOff(void);
+  void SetAdcState(bool state);
+  // -- sleep
+  void PrepareToSleep(void);
+  void RestoreFromLightSleep(void);
+  void DeepSleep(uint64_t time_in_us = 0);
+  void LightSleep(uint64_t time_in_us = 0);
+  uint8_t GetWarningLeve(void);
+
+  // void SetChargeVoltage( uint8_t );
+  // void SetChargeCurrent( uint8_t );
+  float GetBatVoltage();
+  float GetBatCurrent();
+  float GetVinVoltage();
+  float GetVinCurrent();
+  float GetVBusVoltage();
+  float GetVBusCurrent();
+  float GetTempInAXP192();
+  float GetBatPower();
+  float GetBatChargeCurrent();
+  float GetAPSVoltage();
+  float GetBatCoulombInput();
+  float GetBatCoulombOut();
+  uint8_t GetWarningLevel(void);
+  void SetCoulombClear();
+  void SetLDO2(bool State);
+  void SetDCDC3(bool State);
+
+  uint8_t AXPInState();
+  bool isACIN();
+  bool isCharging();
+  bool isVBUS();
+
+  void SetLDOVoltage(uint8_t number, uint16_t voltage);
+  void SetDCVoltage(uint8_t number, uint16_t voltage);
+  void SetESPVoltage(uint16_t voltage);
+  void SetLcdVoltage(uint16_t voltage);
+  void SetLDOEnable(uint8_t number, bool state);
+  void SetLCDRSet(bool state);
+  void SetBusPowerMode(uint8_t state);
+  void SetLed(uint8_t state);
+  void SetSpkEnable(uint8_t state);
+  void SetCHGCurrent(uint8_t state);
+  void SetPeripherialsPower(uint8_t state);
+
+ private:
+  void Write1Byte(uint8_t Addr, uint8_t Data);
+  uint8_t Read8bit(uint8_t Addr);
+  uint16_t Read12Bit(uint8_t Addr);
+  uint16_t Read13Bit(uint8_t Addr);
+  uint16_t Read16bit(uint8_t Addr);
+  uint32_t Read24bit(uint8_t Addr);
+  uint32_t Read32bit(uint8_t Addr);
+  void ReadBuff(uint8_t Addr, uint8_t Size, uint8_t *Buff);
+};
+
+#endif

--- a/player/src/Button.h
+++ b/player/src/Button.h
@@ -65,7 +65,7 @@ void buttonInit(){
 
 void buttonLoop(){
   static uint_fast64_t buttonTimeStamp = 0;
-  if (millis() - buttonTimeStamp > 80) {
+  if (millis() - buttonTimeStamp > 20) {
     buttonTimeStamp = millis();
     #ifdef M5CORE2
     pos = Touch.getPressPoint();

--- a/player/src/Button.h
+++ b/player/src/Button.h
@@ -1,6 +1,14 @@
 #include <Arduino.h>
+#ifdef M5CORE2
+#include "M5Touch.h"
+M5Touch Touch;
+#endif
 
 bool buttonRight(){
+#ifdef M5CORE2
+  TouchPoint_t pos   = Touch.getPressPoint();
+  if(pos.x>100) return true;
+#endif
 #ifdef BUTTON_R
   return (digitalRead(BUTTON_R) == 0);
 #endif
@@ -8,6 +16,10 @@ bool buttonRight(){
 }
 
 bool buttonLeft(){
+#ifdef M5CORE2
+  TouchPoint_t pos   = Touch.getPressPoint();
+  if(pos.x > 0 && pos.x<100) return true;
+#endif
 #ifdef BUTTON_L
   return (digitalRead(BUTTON_L) == 0);
 #endif
@@ -29,6 +41,7 @@ void buttonInit(){
   pinMode(BUTTON_L, INPUT_PULLUP);
   pinMode(BUTTON_R, INPUT);
   #endif
+  Touch.begin();
 #endif
 }
 

--- a/player/src/Button.h
+++ b/player/src/Button.h
@@ -5,8 +5,8 @@ M5Touch Touch;
 TouchPoint_t pos;   
 #endif
 
-int _btn_left;
-int _btn_right;
+int _btn_left=-1;
+int _btn_right=-1;
 
 bool buttonRight(){
 #ifdef M5CORE2

--- a/player/src/Button.h
+++ b/player/src/Button.h
@@ -2,26 +2,42 @@
 #ifdef M5CORE2
 #include "M5Touch.h"
 M5Touch Touch;
+TouchPoint_t pos;   
 #endif
+
+int _btn_left;
+int _btn_right;
 
 bool buttonRight(){
 #ifdef M5CORE2
-  TouchPoint_t pos   = Touch.getPressPoint();
-  if(pos.x>100) return true;
+  if (pos.x > 200 && pos.y > 90 && pos.y < 180) return true;
 #endif
 #ifdef BUTTON_R
-  return (digitalRead(BUTTON_R) == 0);
+  return (_btn_right == 0);
 #endif
   return false;
 }
 
 bool buttonLeft(){
 #ifdef M5CORE2
-  TouchPoint_t pos   = Touch.getPressPoint();
-  if(pos.x > 0 && pos.x<100) return true;
+  if (pos.x > 0 && pos.x < 100 && pos.y > 90 && pos.y < 180) return true;
 #endif
 #ifdef BUTTON_L
-  return (digitalRead(BUTTON_L) == 0);
+  return (_btn_left == 0);
+#endif
+  return false;
+}
+
+bool buttonUp(){
+#ifdef M5CORE2
+  if (pos.x > 106 && pos.x < 212 && pos.y > 0 && pos.y < 90) return true;
+#endif
+  return false;
+}
+
+bool buttonDown(){
+#ifdef M5CORE2
+  if (pos.x > 106 && pos.x < 212 && pos.y > 180 && pos.y < 280) return true;
 #endif
   return false;
 }
@@ -29,7 +45,7 @@ bool buttonLeft(){
 bool buttonPowerOff() {
 #ifdef BUTTON_L
   #ifdef BUTTON_R
-    return (digitalRead(BUTTON_L) == 0 && digitalRead(BUTTON_R) == 0);
+    return (_btn_left == 0 && _btn_right == 0);
   #endif
 #endif
   return false;
@@ -41,7 +57,27 @@ void buttonInit(){
   pinMode(BUTTON_L, INPUT_PULLUP);
   pinMode(BUTTON_R, INPUT);
   #endif
+#endif
+#ifdef M5CORE2
   Touch.begin();
 #endif
 }
+
+void buttonLoop(){
+  static uint_fast64_t buttonTimeStamp = 0;
+  if (millis() - buttonTimeStamp > 80) {
+    buttonTimeStamp = millis();
+    #ifdef M5CORE2
+    pos = Touch.getPressPoint();
+    // Serial.printf("(%i,%i)",pos.x,pos.y);
+    #endif
+    #ifdef BUTTON_L
+      #ifdef BUTTON_R
+    _btn_right = digitalRead(BUTTON_R);
+    _btn_left = digitalRead(BUTTON_L);
+      #endif
+    #endif
+  }
+}
+
 

--- a/player/src/M5PointAndZone.cpp
+++ b/player/src/M5PointAndZone.cpp
@@ -1,0 +1,181 @@
+#include "M5PointAndZone.h"
+
+// Point class
+
+Point::Point(int16_t x_ /* = INVALID_VALUE */,
+             int16_t y_ /* = INVALID_VALUE */) {
+  x = x_;
+  y = y_;
+}
+
+bool Point::operator==(const Point& p) { return (Equals(p)); }
+
+bool Point::operator!=(const Point& p) { return (!Equals(p)); }
+
+Point::operator char*() {
+  if (valid()) {
+    sprintf(_text, "(%d, %d)", x, y);
+  } else {
+    strncpy(_text, "(invalid)", 12);
+  }
+  return _text;
+}
+
+Point::operator bool() { return !(x == INVALID_VALUE && y == INVALID_VALUE); }
+
+void Point::set(int16_t x_ /* = INVALID_VALUE */,
+                int16_t y_ /* = INVALID_VALUE */) {
+  x = x_;
+  y = y_;
+}
+
+bool Point::Equals(const Point& p) { return (x == p.x && y == p.y); }
+
+bool Point::in(Zone& z) { return (z.contains(x, y)); }
+
+bool Point::valid() { return !(x == INVALID_VALUE && y == INVALID_VALUE); }
+
+uint16_t Point::distanceTo(const Point& p) {
+  int16_t dx = x - p.x;
+  int16_t dy = y - p.y;
+  return sqrt(dx * dx + dy * dy) + 0.5;
+}
+
+uint16_t Point::directionTo(const Point& p, bool rot1 /* = false */) {
+  // 57.29578 =~ 180/pi, see https://stackoverflow.com/a/62486304
+  uint16_t a = (uint16_t)(450.5 + (atan2(p.y - y, p.x - x) * 57.29578));
+#ifdef TFT
+  if (rot1) {
+    if (TFT->rotation < 4) {
+      a = (((TFT->rotation + 3) % 4) * 90) + a;
+    } else {
+      a = (((TFT->rotation + 1) % 4) * 90) - a;
+    }
+  }
+#endif /* TFT */
+  a = (360 + a) % 360;
+  return a;
+}
+
+bool Point::isDirectionTo(const Point& p, int16_t wanted,
+                          uint8_t plusminus /* = PLUSMINUS */,
+                          bool rot1 /* = false */) {
+  uint16_t a = directionTo(p, rot1);
+  return (min(abs(wanted - a), 360 - abs(wanted - a)) <= plusminus);
+}
+
+void Point::rotate(uint8_t m) {
+  if (m == 1 || !valid()) return;
+  int16_t normal_x = x;
+  int16_t normal_y = y;
+  int16_t inv_x = HIGHEST_X - x;
+  int16_t inv_y = HIGHEST_Y - y;
+  // inv_y can be negative for area below screen of M5Core2
+  switch (m) {
+    case 0:
+      x = inv_y;
+      y = normal_x;
+      break;
+    case 2:
+      x = normal_y;
+      y = inv_x;
+      break;
+    case 3:
+      x = inv_x;
+      y = inv_y;
+      break;
+    // rotations 4-7 are mirrored
+    case 4:
+      x = inv_y;
+      y = inv_x;
+      break;
+    case 5:
+      x = normal_x;
+      y = inv_y;
+      break;
+    case 6:
+      x = normal_y;
+      y = normal_x;
+      break;
+    case 7:
+      x = inv_x;
+      y = normal_y;
+      break;
+  }
+}
+
+// Zone class
+
+Zone::Zone(int16_t x_ /* = INVALID_VALUE */, int16_t y_ /* = INVALID_VALUE */,
+           int16_t w_ /* = 0 */, int16_t h_ /* = 0 */, bool rot1_ /* = false */
+) {
+  set(x_, y_, w_, h_, rot1_);
+}
+
+Zone::operator bool() { return !(x == INVALID_VALUE && y == INVALID_VALUE); }
+
+void Zone::set(int16_t x_ /* = INVALID_VALUE */,
+               int16_t y_ /* = INVALID_VALUE */, int16_t w_ /* = 0 */,
+               int16_t h_ /* = 0 */, bool rot1_ /* = false */) {
+  x = x_;
+  y = y_;
+  w = w_;
+  h = h_;
+  rot1 = rot1_;
+}
+
+bool Zone::valid() { return !(x == INVALID_VALUE && y == INVALID_VALUE); }
+
+bool Zone::contains(const Point& p) { return contains(p.x, p.y); }
+
+bool Zone::contains(int16_t x_, int16_t y_) {
+#ifdef TFT
+  if (rot1 && TFT->rotation != 1) {
+    Zone t = *this;
+    t.rotate(TFT->rotation);
+    return (y_ >= t.y && y_ <= t.y + t.h && x_ >= t.x && x_ <= t.x + t.w);
+  }
+#endif /* TFT */
+
+  return (y_ >= y && y_ <= y + h && x_ >= x && x_ <= x + w);
+}
+
+void Zone::rotate(uint8_t m) {
+  if (m == 1) return;
+  int16_t normal_x = x;
+  int16_t normal_y = y;
+  int16_t inv_x = TFT_WIDTH - 1 - x - w;
+  int16_t inv_y = TFT_HEIGHT - 1 - y - h;  // negative for area below screen
+  switch (m) {
+    case 0:
+      x = inv_y;
+      y = normal_x;
+      break;
+    case 2:
+      x = normal_y;
+      y = inv_x;
+      break;
+    case 3:
+      x = inv_x;
+      y = inv_y;
+      break;
+    // rotations 4-7 are mirrored
+    case 4:
+      x = inv_y;
+      y = inv_x;
+      break;
+    case 5:
+      x = normal_x;
+      y = inv_y;
+      break;
+    case 6:
+      x = normal_y;
+      y = normal_x;
+      break;
+    case 7:
+      x = inv_x;
+      y = normal_y;
+      break;
+  }
+  if (!(m % 2)) std::swap(w, h);
+}

--- a/player/src/M5PointAndZone.h
+++ b/player/src/M5PointAndZone.h
@@ -1,0 +1,189 @@
+/*
+
+== The PointAndZone Library ==
+
+  This library was written to supply Point and Zone, common primitives for
+  M5Display and M5Button, libraries originally written for the M5Stack series
+  of devices. They could be useful for many other applications, especially
+  anything based on a TFT_eSPI display driver.
+
+
+== Point and Zone: Describing Points and Areas on the Screen ==
+
+  The Point and Zone classes allow you to create variables that hold a point
+  or an area on the screen.
+
+  Point(x, y)
+
+    Holds a point on the screen. Has members x and y that hold the coordinates
+    of a touch. Values INVALID_VALUE for x and y indicate an invalid value,
+    and that's what a point starts out with if you declare it without
+    parameters. The 'valid()' method tests if a point is valid. If you
+    explicitly evaluate a Point as a boolean ("if (p) ..."), you also get
+    whether the point is valid, so this is equivalent to writing "if
+    (p.valid()) ...".
+
+  Zone(x, y, w, h)
+
+    Holds a rectangular area on the screen. Members x, y, w and h are for the
+    x and y coordinate of the top-left corner and the width and height of the
+    rectangle.
+
+  The 'set' method allows you to change the properties of an existing Point
+  or Zone. Using the 'in' or 'contains' method you can test if a point lies
+  in a zone.
+
+  The PointAndZone library also provides the low-level support for direction
+  from one point to another and for screen rotation translations.
+
+
+== Looking for Directions? ==
+
+  This library allows you to find the distance in pixels between two Point
+  objects with "A.distanceTo(B)". Using "A.directionTo(B)" will output a
+  compass course in degrees from A to B. That is, if A lies directly above A
+  on the screen the output will be 0, if B lies to the left of A, the output
+  will be 270. You can also test whether a direction matches some other
+  direction by using "A.isDirectionTo(B, 0, 30)". What this does is take the
+  direction from A to B and output 'true' if it is 0, plus or minus 30
+  degrees. (So either between 330 and 359 or between 0 and 30).
+
+  Do note that unlike in math, on a display the Y-axis points downwards. So
+  pixel coordinates (10, 10) are at direction 135 deg from (0, 0).
+
+  As a last argument to the direction functions, you can supply 'rot1' again
+  (default is 'false'). Just like in zones and buttons, what that means is
+  that the direction is output as if the rotation 1 coordinate system was
+  used.
+
+  Distance and direction functionality is used in Gesture recognition in the
+  M5Button highler level library. Its 'Event' objects have methods that look
+  very much like these, except the 'To' in the name is missing because Events
+  have a starting and ending point so you can just print
+  "myEvent.direction()" or state "if (myEvent.isDirection(0,30) ..."
+
+
+== Some Examples ==
+
+  Point a;
+  Point b(50, 120);
+  Serial.println(a.valid());                    // 0
+  Serial.println(a);                            // (invalid)
+  a.set(10, 30);
+  Serial.println(a);                            // (10,30)
+  Serial.println(a.valid());                    // 1
+  Serial.println(b.y);                          // 120
+  Serial.println(a.distanceTo(b));              // 98
+  Serial.println(a.directionTo(b));             // 156
+  Serial.println(a.isDirectionTo(b, 0, 30));    // 0
+  Zone z(0,0,100, 100);
+  Serial.println(z.w);                          // 100
+  Serial.println(z.contains(a));                // 1
+  Serial.println(b.in(z));                      // 0
+
+
+== Screen Rotation and the 'rot1' Property ==
+
+  TL;DR:  just set it to 'false' if you don't need anything special,
+          otherwise read the rest of this section.
+
+  The TFT_eSPI library allows you to rotate the screen. On M5Stack devices,
+  you do this with "M5.Lcd.SetRotation", supplying a number between 0 and 7.
+  Numbers 0-3 are the obvious rotations, with 1 being the default. 4-7 are
+  the other 4 mirrored, so you would not be using these unless you want to
+  look at the display through a mirror for a homebrew heads-up display or
+  mini-teleprompter.
+
+  The M5Touch library for the Core2 device rotates the data it reads from the
+  sensor to match the display using the 'rotate' function on the Point
+  objects it reads. So if the display is upside down (rotation 3), the (0,
+  0)-point is diagonally accross from where it is in rotation 1. (And the
+  area that was below the screen at y 240-279 now has negative y-values.)
+
+  Zones (and buttons, because they are extensions of zones) have a 'rot1'
+  property. This would normally set to false, meaning the coordinates are
+  treated as specified in the current rotation. If it is set to 'true'
+  however, the library treats the cordinates as if they are specified in
+  rotation 1 and internally rotates them before evaluating whether a Point is
+  in a Zone. The Button object also rotates the coordinates before drawing
+  the button.
+
+  So by setting 'rot1' to true, you can create zones and buttons that stay in
+  the same place even if the screen is rotated. On the Core2, this is used to
+  define the BtnA through BtnC virtual below-screen buttons, which should
+  always be in the area below the screen where the circles are printed,
+  regardless of rotation.
+
+
+== Porting ==
+
+  To use this library on other devices, simply replace these two lines
+
+    #include <M5Display.h>        // so that we can get the rotation
+    #include "utility/Config.h"   // Defines 'TFT', a pointer to the display
+
+  by whatever you need to do to make the symbol 'TFT' be a pointer to a
+  TFT_eSPI-derived display device that has a 'rotation' variable. If you
+  don't need rotation just delete the lines: the direction functions and the
+  'contains' function will now simply ignore their 'rot1' parameters.
+
+*/
+
+#ifndef _POINTANDZONE_H_
+#define _POINTANDZONE_H_
+
+#include <Arduino.h>
+#include <TFT_eSPI.h>
+
+#define INVALID_VALUE -32768
+#define PLUSMINUS 45  // default value for isDirectionTo
+
+#define DIR_UP 0
+#define DIR_RIGHT 90
+#define DIR_DOWN 180
+#define DIR_LEFT 270
+#define DIR_ANY INVALID_VALUE
+
+#define HIGHEST_X 319  // Can't trust TFT_WIDTH, driver is portrait
+#define HIGHEST_Y 239
+
+class Zone;
+
+class Point {
+ public:
+  Point(int16_t x_ = INVALID_VALUE, int16_t y_ = INVALID_VALUE);
+  bool operator==(const Point& p);
+  bool operator!=(const Point& p);
+  explicit operator bool();
+  operator char*();
+  void set(int16_t x_ = INVALID_VALUE, int16_t y_ = INVALID_VALUE);
+  bool valid();
+  bool in(Zone& z);
+  bool Equals(const Point& p);
+  uint16_t distanceTo(const Point& p);
+  uint16_t directionTo(const Point& p, bool rot1 = false);
+  bool isDirectionTo(const Point& p, int16_t wanted,
+                     uint8_t plusminus = PLUSMINUS, bool rot1 = false);
+  void rotate(uint8_t m);
+  int16_t x, y;
+
+ private:
+  char _text[12];
+};
+
+class Zone {
+ public:
+  Zone(int16_t x_ = INVALID_VALUE, int16_t y_ = INVALID_VALUE, int16_t w_ = 0,
+       int16_t h_ = 0, bool rot1_ = false);
+  explicit operator bool();
+  bool valid();
+  void set(int16_t x_ = INVALID_VALUE, int16_t y_ = INVALID_VALUE,
+           int16_t w_ = 0, int16_t h_ = 0, bool rot1_ = false);
+  bool contains(const Point& p);
+  bool contains(int16_t x, int16_t y);
+  void rotate(uint8_t m);
+  int16_t x, y, w, h;
+  bool rot1;
+};
+
+#endif /* _POINTANDZONE_H_ */

--- a/player/src/M5Touch.cpp
+++ b/player/src/M5Touch.cpp
@@ -1,0 +1,169 @@
+#include "M5Touch.h"
+// M5Touch class
+
+/* static */ M5Touch* M5Touch::instance;
+
+M5Touch::M5Touch() {
+  if (!instance) instance = this;
+}
+
+void M5Touch::begin() {
+  Wire1.begin(21, 22);
+  pinMode(CST_INT, INPUT);
+
+  // By default, the FT6336 will pulse the INT line for every touch
+  // event. But because it shares the Wire1 TwoWire/I2C with other
+  // devices, we cannot easily create an interrupt service routine to
+  // handle these events. So instead, we set the INT wire to polled mode,
+  // so it simply goes low as long as there is at least one valid touch.
+  ft6336(0xA4, 0x00);
+
+  Serial.print("touch: ");
+  if (interval(DEFAULT_INTERVAL) == DEFAULT_INTERVAL) {
+    Serial.printf("FT6336 ready (fw id 0x%02X rel %d, lib 0x%02X%02X)\n",
+                  ft6336(0xA6), ft6336(0xAF), ft6336(0xA1), ft6336(0xA2));
+  } else {
+    Serial.println("ERROR - FT6336 not responding");
+  }
+}
+
+bool M5Touch::ispressed() { return (digitalRead(CST_INT) == LOW); }
+
+// Single register read and write
+
+uint8_t M5Touch::ft6336(uint8_t reg) {
+  Wire1.beginTransmission((uint8_t)CST_DEVICE_ADDR);
+  Wire1.write(reg);
+  Wire1.endTransmission();
+  Wire1.requestFrom((uint8_t)CST_DEVICE_ADDR, uint8_t(1));
+  return Wire1.read();
+}
+
+void M5Touch::ft6336(uint8_t reg, uint8_t value) {
+  Wire1.beginTransmission(CST_DEVICE_ADDR);
+  Wire1.write(reg);
+  Wire1.write((uint8_t)value);
+  Wire1.endTransmission();
+}
+
+// Reading size bytes into data
+void M5Touch::ft6336(uint8_t reg, uint8_t size, uint8_t* data) {
+  Wire1.beginTransmission((uint8_t)CST_DEVICE_ADDR);
+  Wire1.write(reg);
+  Wire1.endTransmission();
+  Wire1.requestFrom((uint8_t)CST_DEVICE_ADDR, size);
+  for (uint8_t i = 0; i < size; i++) data[i] = Wire1.read();
+}
+
+uint8_t M5Touch::interval(uint8_t ivl) {
+  ft6336(0x88, ivl);
+  return interval();
+}
+
+uint8_t M5Touch::interval() {
+  _interval = ft6336(0x88);
+  return _interval;
+}
+
+// This is normally called from update()
+bool M5Touch::read() {
+  // true if real read, not a "come back later"
+  wasRead = false;
+
+  // true is something actually changed on the touchpad
+  changed = false;
+
+  // Return immediately if read() is called more frequently than the
+  // touch sensor updates. This prevents unnecessary I2C reads, and the
+  // data can also get corrupted if reads are too close together.
+  if (millis() - _lastRead < _interval) return false;
+  _lastRead = millis();
+
+  Point p[2];
+  uint8_t pts = 0;
+  uint8_t p0f = 0;
+  if (ispressed()) {
+    uint8_t data[11];
+    ft6336(0x02, 11, data);
+    pts = data[0];
+    if (pts > 2) return false;
+    if (pts) {
+      // Read the data. Never mind trying to read the "weight" and
+      // "size" properties or using the built-in gestures: they
+      // are always set to zero.
+      p0f = (data[3] >> 4) ? 1 : 0;
+      p[0].x = ((data[1] << 8) | data[2]) & 0x0fff;
+      p[0].y = ((data[3] << 8) | data[4]) & 0x0fff;
+      if (p[0].x >= TOUCH_W || p[0].y >= TOUCH_H) return false;
+      if (pts == 2) {
+        p[1].x = ((data[7] << 8) | data[8]) & 0x0fff;
+        p[1].y = ((data[9] << 8) | data[10]) & 0x0fff;
+        if (p[1].x >= TOUCH_W || p[1].y >= TOUCH_H) return false;
+      }
+    }
+  }
+
+#ifdef TFT
+  p[0].rotate(TFT->rotation);
+  p[1].rotate(TFT->rotation);
+#endif /* TFT */
+
+  if (p[0] != point[0] || p[1] != point[1]) {
+    changed = true;
+    point[0] = p[0];
+    point[1] = p[1];
+    points = pts;
+    point0finger = p0f;
+  }
+  wasRead = true;
+  return true;
+}
+
+Point M5Touch::getPressPoint() {
+  read();
+  if (point[0]) return point[0];
+  return Point(-1, -1);  // -1, -1 is old API's definition of invalid
+}
+
+void M5Touch::update() { read(); }
+
+void M5Touch::dump() {
+  uint8_t data[256] = {0};
+  ft6336(0x00, 0x80, data);
+  ft6336(0x80, 0x80, data + 0x80);
+  Serial.printf("\n     ");
+  for (uint8_t i = 0; i < 16; i++) Serial.printf(".%1X ", i);
+  Serial.printf("\n");
+  for (uint16_t i = 0; i < 0x100; i++) {
+    if (!(i % 16)) Serial.printf("\n%1X.   ", i / 16);
+    Serial.printf("%02X ", data[i]);
+  }
+  Serial.printf("\n\n\n");
+}
+
+// HotZone class (for compatibility with older M5Core2 code)
+
+HotZone::HotZone(int16_t x0_, int16_t y0_, int16_t x1_, int16_t y1_,
+                 void (*fun_)() /* = nullptr */
+                 )
+    : Zone(x0_, y0_, x1_ - x0_, y1_ - y0_) {
+  fun = fun_;
+}
+
+void HotZone::setZone(int16_t x0_, int16_t y0_, int16_t x1_, int16_t y1_,
+                      void (*fun_)() /*= nullptr */
+) {
+  set(x0_, y0_, x1_ - x0_, y1_ - y0_);
+  fun = fun_;
+}
+
+bool HotZone::inHotZone(Point& p) { return contains(p); }
+
+bool HotZone::inHotZoneDoFun(Point& p) {
+  if (contains(p)) {
+    if (fun) fun();
+    return true;
+  } else {
+    return false;
+  }
+}

--- a/player/src/M5Touch.h
+++ b/player/src/M5Touch.h
@@ -1,0 +1,285 @@
+/*
+
+== M5Touch - The M5Stack Core2 Touch Library ==
+
+  This is the library behind the M5.Touch object that you can use to read
+  from the touch sensor on the M5Stack Core2. It was made to be an input
+  source for the M5Button library that provides higher level buttons,
+  gestures and events, but both libraries can be also be used alone.
+
+
+== About the Touch Sensor in the M5Stack Core2 ==
+
+  Touchpanel interfacing is done by a FocalTech FT6336 chip, which supports
+  two simultaneous touches. However, the M5Stack Core2 touch display is only
+  multi-touch in one dimension. What that means is that it can detect two
+  separate touches only if they occur on different vertical positions. This
+  has to do with the way the touch screen is wired, it's not something that
+  can be changed in software. So you will only ever see two points if they do
+  not occur side-by-side. Touches that do happen side-by-side blend into one
+  touch that is detected somewhere between the actual touches.
+
+  While this limits multi-touch somewhat, you can still create multiple
+  buttons and see two that are not on the same row simultaneously. You could
+  also use one of the buttons below the screen as a modifier for something
+  touched on the screen.
+
+  The touch sensor extends to below the screen of the Core2: the sensor maps
+  to 320x280 pixels, the screen is 320x240. The missing 40 pixels are placed
+  below the screen, where the printed circles are. This is meant to simulate
+  the three hardware buttons on the original M5Stack units. Note that on some
+  units the touch sensor in this area only operates properly if the USB cable
+  is plugged in or if the unit is placed firmly in your hand on a metal
+  surface.
+
+  For a quick view of how the sensor sees the world, try this sketch:
+
+    #include <M5Core2.h>
+
+    void setup() {
+      M5.begin();
+      M5.Lcd.fillScreen(WHITE);
+    }
+
+    void loop() {
+      M5.update();
+      Event& e = M5.Buttons.event;
+      if (e & (E_MOVE | E_RELEASE)) circle(e & E_MOVE ? e.from : e.to, WHITE);
+      if (e & (E_TOUCH | E_MOVE)) circle(e.to, e.finger ? BLUE : RED);
+    }
+
+    void circle(Point p, uint16_t c) {
+      M5.Lcd.drawCircle(p.x, p.y, 50, c);
+      M5.Lcd.drawCircle(p.x, p.y, 52, c);
+    }
+
+  (Don't worry if this all seems abracadabra now, we'll get to all of
+  this is due time.)
+
+
+== Point and Zone: Describing Points and Areas on the Screen ==
+
+  The Point and Zone classes allow you to create variables that hold a point
+  or an area on the screen. You can
+
+  Point(x, y)
+
+    Holds a point on the screen. Has members x and y that hold the coordinates
+    of a touch. Values INVALID_VALUE for x and y indicate an invalid value,
+    and that's what a point starts out with if you declare it without
+    parameters. The 'valid()' method tests if a point is valid. If you
+    explicitly evaluate a Point as a boolean ("if (p) ..."), you also get
+    whether the point is valid, so this is equivalent to writing "if
+    (p.valid()) ...".
+
+  Zone(x, y, w, h)
+
+    Holds a rectangular area on the screen. Members x, y, w and h are for the
+    x and y coordinate of the top-left corner and the width and height of the
+    rectangle.
+
+  The 'set' method allows you to change the properties of an existing Point
+  or Zone. Using the 'in' or 'contains' method you can test if a point lies
+  in a zone.
+
+  The PointAndZone library also provides the low-level support for direction
+  from one point to another and for screen rotation translations.
+
+  The documentation in src/utility/PointAndZone.h provides more details and
+  examples.
+
+
+== Basic Touch API ==
+
+  The basic touch API provides a way to read the data from the touch sensor.
+
+
+  M5.update()
+    In the loop() part of your sketch, call "M5.update()". This will in turn
+    call M5.Touch.update(), which is the only part that talks to the touch
+    interface. It updates the data used by the rest of the API.
+
+  M5.Touch.changed
+    Is true if anything changed on the touchpad since the last time
+    M5.update() was called.
+
+  M5.Touch.points
+    Contains the number of touches detected: 0, 1 or 2.
+
+  M5.Touch.point[0], M5.Touch.point[1]
+    M5.Touch.point[0] and M5.Touch.point[1] are Points that hold the detected
+    touches.
+
+
+  A very simple sketch to print the location where the screen is touched:
+
+    #include <M5Core2.h>
+
+    void setup() {
+      M5.begin();
+    }
+
+    void loop() {
+      M5.update();
+      if ( M5.Touch.changed ) Serial.println( M5.Touch.point[0] );
+    }
+
+
+== Buttons, Gestures, Events ==
+
+  Note that you may not want to use any of the above directly. The M5Buttons
+  library provides button, gestures and events that allow you to quickly
+  create reactive visual buttons on the screen and react differently based on
+  whether a button was clicked, tapped, or double-tapped. Have a look at the
+  documentation for that, which is in the M5Button.h file in the src/utility
+  directory of this repository. The examples under "File / Examples
+  / M5Core2 / Touch" in your Arduino environment should give you an
+  idea of what's possible.
+
+
+== Screen Rotation ==
+
+  If you rotate the screen with M5.Lcd.setRotation, the touch coordinates
+  will rotate along with it.
+
+  * What that means is that either x or y for the area below the screen may
+    go negative. Say you use the screen upside-down with
+    M5.Lcd.setRotation(3). In that case the off-screen touch area (Y
+    coordinates 240 through 279) that was below the screen now becomes above
+    the screen and has Y coordinates -40 through -1.
+
+  * See the M5Button library for a feature that allows you to keep some Zone
+    and Button objects in the same place on the physical screen, regardless
+    of rotation.
+
+
+== TFT_eSPI Resistive Touch API emulation ==
+
+  While technically not part of this library itself, we added an emulation
+  for the TFT_eSPI touch API to the M5Display object that merely passes
+  informaton on to the M5.Touch object. So M5.Lcd can be addressed as if it's
+  a touch screen using that older resistive touch interface. Do note that
+  this interface is not nearly as powerful as M5.Touch's native API. But
+  together with M5Button's TFT_eSPI_Button emulation, this should allow you
+  to compile lots of ESP32 software written for touch screens.
+
+
+== Advanced Uses of the Touch Library ==
+
+  You should never need any of the below features in everyday use. But
+  they're there just in case...
+
+  M5.Touch.wasRead
+    True if the sensor was actually read. The sensor can only provide updates
+    every 13 milliseconds or so. M5.update() can loop as quick as once every
+    20 MICROseconds, meaning it would continually read the sensor when there
+    was nothing to read. So M5.Touch.read() only really reads when it's time
+    to do so, and returns with M5.Touch.wasRead false otherwise.
+
+  M5.point0finger
+    The FT6336 chip keeps track of fingers, each touch has a finger ID of 0
+    or 1. So when there are two touches in point[0] and point[1] and then one
+    goes away, point0finger allows you to see which touch is left in
+    point[0].
+
+  M5.Touch.interval()
+    Without arguments returns the current interval between sensor updates in
+    milliseconds. If you supply a number that's the new interval. The default
+    of 13 seems to give the most updates per second.
+
+  M5.Touch.ft6336(reg)
+  M5.Touch.ft6336(reg, value)
+  M5.Touch.ft6336(reg, size, *data)
+    Allows you to read and write registers on the ft6336 touch interface chip
+    directly. The first form reads one byte, the second form writes one and
+    the third form reads a block of 'size' bytes starting at 'reg' into a
+    buffer at '*data'.
+
+  M5.Touch.dump()
+    M5.Touch.dump() dumps the entire register space on the FT6336 chip as a
+    formatted hexdump to the serial port.
+
+
+== Legacy API ==
+
+  There was a previous version of this library, and it provided a number of
+  functions that were single touch only. The older version did not have
+  M5.update(). Instead it used ispressed() and getPressedPoint() functions as
+  well as HotZones, which provided something that worked a little bit like
+  Buttons. This older API is still supported (the M5Core2 Factory Test sketch
+  still works), but you should not use it for new programs. The ispressed()
+  function specifically does not mix well with code that uses M5.update().
+
+
+== Example ==
+
+  It may sound complicated when you read it all in this document, but it's
+  all made to be easy to use.
+
+  Under File / Examples / M5Core2 / Touch in your Arduino environment is an
+  example sketch called "events_buttons_gestures_rotation" that shows both
+  this library and M5Button in action. Please have a look at it to understand
+  how this all works and run the sketch to see all the events printed to the
+  serial port. It shows buttons, gestures and events and should be pretty
+  self-explanatory.
+
+*/
+
+#ifndef _M5TOUCH_H_
+#define _M5TOUCH_H_
+
+#include <Arduino.h>
+#include <Wire.h>
+#include "M5PointAndZone.h"
+
+#define TOUCH_W 320
+#define TOUCH_H 280
+#define CST_DEVICE_ADDR 0x38
+#define CST_INT 39
+
+// Strangely, the value 13 leads to slightly more frequent updates than 10
+// (Still not every 13 ms, often more like 15 to 20)
+#define DEFAULT_INTERVAL 13
+
+class M5Touch {
+ public:
+  static M5Touch* instance;
+  M5Touch();
+  void begin();
+  uint8_t ft6336(uint8_t reg);
+  void ft6336(uint8_t reg, uint8_t value);
+  void ft6336(uint8_t reg, uint8_t size, uint8_t* data);
+  uint8_t interval(uint8_t ivl);
+  uint8_t interval();
+  void update();
+  bool read();
+  bool ispressed();
+  void dump();
+  Point getPressPoint();
+  uint8_t points;
+  bool changed, wasRead;
+  Point point[2];
+  uint8_t point0finger;
+
+ protected:
+  uint8_t _interval;
+  uint32_t _lastRead;
+};
+
+// For compatibility with older M5Core2 code
+class HotZone : public Zone {
+ public:
+  HotZone(int16_t x0_, int16_t y0_, int16_t x1_, int16_t y1_,
+          void (*fun_)() = nullptr);
+  void setZone(int16_t x0_, int16_t y0_, int16_t x1_, int16_t y1_,
+               void (*fun_)() = nullptr);
+  bool inHotZone(Point& p);
+  bool inHotZoneDoFun(Point& p);
+  void (*fun)();
+};
+
+#define HotZone_t HotZone
+#define TouchPoint Point
+#define TouchPoint_t Point
+
+#endif /* _M5TOUCH_H_ */

--- a/player/src/PowerUtils.h
+++ b/player/src/PowerUtils.h
@@ -1,10 +1,14 @@
-
 #ifdef TDISPLAY        // TODO: We need that because the current "touch-down" variant don't compile with these definitions
 #include <Arduino.h>
 #include <driver/rtc_io.h>
 #include <esp_bt.h>
 #include <esp_bt_main.h>
 #include <esp_wifi.h>
+#endif
+#ifdef M5CORE2
+#include "AXP192.h"
+
+AXP192 Axp;
 #endif
 
 void powerDeepSeep() {
@@ -30,5 +34,12 @@ void powerInit() {
 #ifdef TDISPLAY
   pinMode(HW_EN, OUTPUT);
   digitalWrite(HW_EN, HIGH);  // step-up on
+#endif
+#ifdef M5CORE2
+  Axp.begin();
+  Axp.SetLcdVoltage(3300);
+  Axp.SetBusPowerMode(0);
+  Axp.SetCHGCurrent(AXP192::kCHG_190mA);
+  Axp.SetSpkEnable(true);
 #endif
 }

--- a/player/src/audio_output/AudioOutput.h
+++ b/player/src/audio_output/AudioOutput.h
@@ -26,6 +26,11 @@ public:
   void write(int8_t *samples, int count);
   void write(int16_t *samples, int count);
 
+  void setVolume(int volume){
+    if (volume > 10 || volume < 0) mVolume = 10;
+    else mVolume = volume;
+  }
+
   void volumeUp() {
     if (mVolume == 10) {
       return;

--- a/player/src/main.cpp
+++ b/player/src/main.cpp
@@ -123,6 +123,9 @@ void setup()
   videoPlayer->setChannel(0);
   videoPlayer->play();
 #endif
+  #ifdef M5CORE2
+  audioOutput->setVolume(4);
+  #endif
 }
 
 int channel = 0;

--- a/player/src/main.cpp
+++ b/player/src/main.cpp
@@ -25,7 +25,9 @@ const char *CHANNEL_INFO_URL = "http://192.168.1.229:8123/channel_info";
 #ifdef HAS_IR_REMOTE
 RemoteInput *remoteInput = NULL;
 #else
+#ifndef HAS_BUTTONS
 #warning "No Remote Input - Will default to playing channel 0"
+#endif
 #endif
 
 #ifndef USE_DMA
@@ -69,6 +71,9 @@ void setup()
 
   tft.init();
   tft.setRotation(3);
+  #ifdef M5CORE2
+  tft.setRotation(6);
+  #endif
   tft.fillScreen(TFT_BLACK);
   #ifdef USE_DMA
   tft.initDMA();
@@ -122,6 +127,18 @@ void setup()
 
 int channel = 0;
 
+void volumeUp() {
+  audioOutput->volumeUp();
+  delay(500);
+  Serial.println("VOLUME_UP");
+}
+
+void volumeDown() {
+  audioOutput->volumeDown();
+  delay(500);
+  Serial.println("VOLUME_DOWN");
+}
+
 void channelDown() {
   videoPlayer->playStatic();
   delay(500);
@@ -166,11 +183,10 @@ void loop()
       videoPlayer->play();
       break;
     case RemoteCommands::VOLUME_UP:
-      audioOutput->volumeUp();
+      volumeUp();
       break;
     case RemoteCommands::VOLUME_DOWN:
-      audioOutput->volumeDown();
-      Serial.println("VOLUME_DOWN");
+      volumeDown();
       break;
     case RemoteCommands::CHANNEL_UP:
       channelUp();
@@ -183,14 +199,24 @@ void loop()
     remoteInput->getLatestCommand();
   }
 #endif
+#ifdef HAS_BUTTONS
   if (buttonLeft()) {
-    channelUp();
-  }
-  if (buttonRight()) {
     channelDown();
   }
+  if (buttonRight()) {
+    channelUp();
+  }
+  if (buttonUp()) {
+    volumeUp();
+  }
+  if (buttonDown()) {
+    volumeDown();
+  }
   if (buttonPowerOff()) {
+    Serial.println("POWER OFF");
+    delay(500);
     powerDeepSeep();
   }
-  delay(100);
+  buttonLoop();
+#endif
 }


### PR DESCRIPTION
## Overview

Added M5Core2 support and some improvements to previous version of TDisplay

## Features

- [x] It use the official  TFT_eSPI library instead deprecated M5Core2 library
- [x] Touch support (volume up/down and channel +/-)
- [x] Added setVolume method (M5Core2 speaker is really noise)
- [x] improved to stable Espressif version for ESP32 core (v4.4.0) 

## Tests

- [x] compiling on all variants
- [x] TDisplay with SDCARD
- [x] M5Core2 with Python server
- [x] SD config ready. Detection ready but [mount fails](https://github.com/m5stack/M5Core2/issues/136)  


https://github.com/atomic14/esp32-tv/assets/423856/bd3ca8b6-abb8-4369-b602-0e6230336731

