### PR TITLE
Show when SD Card fails to mount

### DIFF
--- a/player/src/Displays/Matrix.cpp
+++ b/player/src/Displays/Matrix.cpp
@@ -52,6 +52,14 @@ void Matrix::drawTuningText() {
   dma_display->println("TUNING...");
 }
 
+void Matrix::drawSDCardFailed() {
+  // fill the screen with red
+  dma_display->fillScreen(0xf800);
+  dma_display->setCursor(20, 20);
+  dma_display->setTextColor(0xffff, 0x0000);
+  dma_display->println("SD Card Failed");
+}
+
 void Matrix::drawFPS(int fps) {
   // show the frame rate in the top right
   dma_display->setCursor(width() - 50, 20);

--- a/player/src/Displays/Matrix.h
+++ b/player/src/Displays/Matrix.h
@@ -18,4 +18,5 @@ public:
   void drawChannel(int channelIndex);
   void drawTuningText();
   void drawFPS(int fps);
+  void drawSDCardFailed();
 };

--- a/player/src/Displays/TFT.cpp
+++ b/player/src/Displays/TFT.cpp
@@ -80,6 +80,14 @@ void TFT::drawTuningText() {
   tft->println("TUNING...");
 }
 
+void TFT::drawSDCardFailed() {
+  tft->fillScreen(TFT_RED);
+  tft->setCursor(0, 20);
+  tft->setTextColor(TFT_WHITE);
+  tft->setTextSize(2);
+  tft->println("Failed to mount SD Card");
+}
+
 void TFT::drawFPS(int fps) {
     // show the frame rate in the top right
     tft->setCursor(width() - 50, 20);

--- a/player/src/Displays/TFT.h
+++ b/player/src/Displays/TFT.h
@@ -20,5 +20,6 @@ public:
   void drawChannel(int channelIndex);
   void drawTuningText();
   void drawFPS(int fps);
+  void drawSDCardFailed();
 };
 #endif

--- a/player/src/main.cpp
+++ b/player/src/main.cpp
@@ -71,6 +71,14 @@ void setup()
   #else
   SDCard *card = new SDCard(SD_CARD_MISO, SD_CARD_MOSI, SD_CARD_CLK, SD_CARD_CS);
   #endif
+  // check that the SD Card has mounted properly
+  if (!card->isMounted()) {
+    Serial.println("Failed to mount SD Card");
+    display.drawSDCardFailed();
+    while(true) {
+      delay(1000);
+    }
+  }
   channelData = new SDCardChannelData(card, "/");
   audioSource = new SDCardAudioSource((SDCardChannelData *) channelData);
   videoSource = new SDCardVideoSource((SDCardChannelData *) channelData);


### PR DESCRIPTION
Don't go into an infinite loop when the SD Card fails to mount.

Helps to troubleshoot #19 