### PR TITLE
Use lower SD card frequency for wider range of cards (fixes #19)

### DIFF
--- a/player/src/SDCard.cpp
+++ b/player/src/SDCard.cpp
@@ -70,7 +70,7 @@ SDCard::SDCard(gpio_num_t clk, gpio_num_t cmd, gpio_num_t d0, gpio_num_t d1, gpi
 
 SDCard::SDCard(gpio_num_t miso, gpio_num_t mosi, gpio_num_t clk, gpio_num_t cs)
 {
-  m_host.max_freq_khz = SDMMC_FREQ_52M;
+  m_host.max_freq_khz = SDMMC_FREQ_DEFAULT; // A faster speed can be used if your card supports it
   esp_err_t ret;
   // Options for mounting the filesystem.
   // If format_if_mount_failed is set to true, SD card will be partitioned and


### PR DESCRIPTION
As per https://github.com/atomic14/esp32-tv/issues/19 this PR reduces the SD card max frequency to use SDMMC_FREQ_DEFAULT which has been seen to support a wider range of SD cards that might be used.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced SD card performance by allowing for flexible maximum frequency settings, improving speed based on card capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->