### PR TITLE
Attempt to address SPI SDCard speed limits

### DIFF
--- a/player/platformio.ini
+++ b/player/platformio.ini
@@ -168,6 +168,8 @@ build_flags =
   -DSD_CARD_MOSI=GPIO_NUM_23
   -DSD_CARD_CLK=GPIO_NUM_18
   -DSD_CARD_CS=GPIO_NUM_5
+  ; increase file buffer size to prevent playback stalling on SD Card read
+  -DFILE_BUFFER_SIZE=16384
 
 [env:touch-down]
 extends = esp32_common
@@ -235,6 +237,8 @@ build_flags =
   -DSD_CARD_MOSI=GPIO_NUM_15
   -DSD_CARD_CLK=GPIO_NUM_13
   -DSD_CARD_CS=GPIO_NUM_2
+  ; increase file buffer size to prevent playback stalling on SD Card read
+  -DFILE_BUFFER_SIZE=16384
 
 [env:m5core2]
 extends = esp32_common 

--- a/player/src/AVIParser/AVIParser.cpp
+++ b/player/src/AVIParser/AVIParser.cpp
@@ -60,18 +60,16 @@ bool AVIParser::isMoviListChunk(unsigned int chunkSize)
 bool AVIParser::open()
 {
   mFile = fopen(mFileName.c_str(), "rb");
-
-  #ifdef FILE_BUFFER_SIZE
-  // Increase size of file buffer if needed.
-  Serial.printf("Setting file buffer size to %d bytes.\n", FILE_BUFFER_SIZE);
-  setvbuf(mFile, NULL, _IOFBF, FILE_BUFFER_SIZE);
-  #endif
-
   if (!mFile)
   {
     Serial.printf("Failed to open file.\n");
     return false;
   }
+  #ifdef FILE_BUFFER_SIZE
+  // Increase size of file buffer if needed.
+  Serial.printf("Setting file buffer size to %d bytes.\n", FILE_BUFFER_SIZE);
+  setvbuf(mFile, NULL, _IOFBF, FILE_BUFFER_SIZE);
+  #endif
   // check the file is valid
   ChunkHeader header;
   // Read RIFF header

--- a/player/src/AVIParser/AVIParser.h
+++ b/player/src/AVIParser/AVIParser.h
@@ -20,5 +20,5 @@ public:
   AVIParser(std::string fname, AVIChunkType requiredChunkType);
   ~AVIParser();
   bool open();
-  size_t getNextChunk(uint8_t **buffer, size_t &bufferLength);
+  size_t getNextChunk(uint8_t **buffer, size_t &bufferLength, bool skipRead=false);
 };

--- a/player/src/VideoSource/SDCardVideoSource.cpp
+++ b/player/src/VideoSource/SDCardVideoSource.cpp
@@ -44,12 +44,19 @@ bool SDCardVideoSource::getVideoFrame(uint8_t **buffer, size_t &bufferLength, si
   }
   // Skip some number of frames if we have fallen behind
   while (targetFrame - mFrameCount > 1){
+    size_t skipped = parser->getNextChunk(buffer, bufferLength, true);
+    if (skipped == 0) {
+      // No more data or error — bail without advancing the frame counter.
+      return false;
+    }
     mFrameCount++;
-    frameLength = parser->getNextChunk((uint8_t **)buffer, bufferLength, true);
   }
   // We are caught up to targetFrame-1, so load the next frame to show.
+  frameLength = parser->getNextChunk(buffer, bufferLength);
+  if (frameLength == 0){
+    return false;
+  }
   mFrameCount++;
-  frameLength = parser->getNextChunk((uint8_t **)buffer, bufferLength);
 
   return true;
 }


### PR DESCRIPTION
Addresses #26

This is an attempt to address issues with playback from the SD Card. After some amount of time (about a minute or two in my case) playback drastically slows from ~15 fps down to 0, and then starts to ruin the audio too. If I wait for the video to restart, playback resumes at 15fps.

I did some basic profiling and found that the Video task was spending almost all of its time in the `AVIParser::getNextChunk` method, primarily on the `fread(*buffer, header.chunkSize, 1, mFile);` function call, but sometimes even spending more than 50ms on the `readChunk(mFile, &header);` call. I think the root cause of the issue is that there are two tasks fighting over the same file resources using two separate File objects, which causes them to get stuck waiting for each other sometimes.

After a bit of experimenting it seems like once the video task falls a little bit behind, it has to play catch up by quickly reading multiple frames from the SD Card before it can finally display a new one, and this is why the issue only gets worse and worse as the video goes on.  
In an attempt to improve the rate of 'catch up', I added an optional `skipRead` parameter to the `getNextChunk` method, which literally just skips the `fread` step when it isn't required. This seemed to improve things slightly in my test, but it only delayed the issue from occurring.  
*(I also noticed that `bufferLength` was always 0 from the video thread. I added a line to update bufferLength to chunkSize when the buffer is reallocated, because I assumed that was the intended behaviour. However, that doesn't seem to have affected speed at all.)*

Finally, I found [this](https://github.com/espressif/esp-idf/issues/3249) issue posted on the esp-idf repo, where it is recommended to try increasing the internal buffer size for a File object if it isn't reading fast enough. I tried some different values, and a 16kb buffer (which happens to correspond to about 2 video frames in my test file) seems to be the sweet spot for my board.

With these changes, video playback speed still drops throughout the playback, but it happens much slower (dropping to 1~3fps after ~10 minutes, rather than ~0fps after ~2 minutes). And, if I re-encode the video (and change DEFAULT_FPS) to 12fps, I can stay at roughly 10-12 fps more consistently.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced SD card playback stalling and dropouts by increasing the file read buffer.
  * Improved timeline continuity by skipping overdue frames during catch-up, avoiding repeated frame reads.

* **Performance**
  * Smoother, more consistent video playback with a larger read buffer.
  * Faster recovery after delays, minimizing visible hitches and reducing frame jitter.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->